### PR TITLE
Feat/remove assumed copy file glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ npm install cartridge-copy-assets --save-dev
 
 Copy tasks are defined in the `task.copy-assets.js` config file. Each key of the `taskConfig` object makes a new gulp task.
 
-The only predefined task, `copy-assets`, runs all copy tasks at once.
+The only predefined task, `copy-assets`, runs all copy tasks one after another.
 
 ### How to add new copy tasks
-To add a new copy task all you have to do is open `task.copy-assets.js` and then add a new key to the `taskConfig` object. For example:
+Copy tasks are described in the config file `task.copy-assets.js`. Adding a new key to the `taskConfig` object outlines a copy task.
 
 ```
 var taskConfig = {
 		fonts: {
-			src: 'path/to/src',
-			dest: 'path/to/dest'
+			src: 'path/to/src', //This can be a file, folder or glob
+			dest: 'path/to/dest' //If directory doesn't exist, it will be created
 		}
 };
 ```

--- a/_config/task.copy-assets.js
+++ b/_config/task.copy-assets.js
@@ -9,11 +9,11 @@ function getTaskConfig(projectConfig) {
 		// 	dest: projectConfig.dirs.build
 		// },
 		// fonts: {
-		// 	src: projectConfig.dirs.src + '/fonts/',
+		// 	src: projectConfig.dirs.src + '/fonts/**/*',
 		// 	dest: projectConfig.dirs.dest + '/fonts/'
 		// },
 		// media: {
-		// 	src: projectConfig.dirs.src + '/media/',
+		// 	src: projectConfig.dirs.src + '/media/**/*',
 		// 	dest: projectConfig.dirs.dest + '/media/'
 		// }
 	};

--- a/task.js
+++ b/task.js
@@ -26,7 +26,7 @@ module.exports = function(gulp, projectConfig, tasks) {
 
 	Object.keys(taskConfig).forEach(function(key) {
 		gulp.task(TASK_NAME + ':' + key, function() {
-			return gulp.src([taskConfig[key].src + '**/*'])
+			return gulp.src([taskConfig[key].src])
 				.pipe(gulp.dest(taskConfig[key].dest));
 		});
 

--- a/task.js
+++ b/task.js
@@ -9,7 +9,7 @@ var path = require('path');
 // Module dependencies
 
 
-module.exports = function(gulp, projectConfig, tasks) {
+module.exports = function copyAssetsModule(gulp, projectConfig, tasks) {
 
 	/* --------------------
 	*	CONFIGURATION
@@ -24,8 +24,8 @@ module.exports = function(gulp, projectConfig, tasks) {
 	*	MODULE TASKS
 	* ---------------------*/
 
-	Object.keys(taskConfig).forEach(function(key) {
-		gulp.task(TASK_NAME + ':' + key, function() {
+	Object.keys(taskConfig).forEach(function loopThroughConfig(key) {
+		gulp.task(TASK_NAME + ':' + key, function copyTask() {
 			return gulp.src([taskConfig[key].src])
 				.pipe(gulp.dest(taskConfig[key].dest));
 		});
@@ -43,7 +43,7 @@ module.exports = function(gulp, projectConfig, tasks) {
 	*	WATCH TASKS
 	* ---------------------*/
 
-	gulp.task('watch:' + TASK_NAME, function () {
+	gulp.task('watch:' + TASK_NAME, function copyWatchTask() {
 		gulp.watch(
 			taskConfig.watch,
 			[TASK_NAME]


### PR DESCRIPTION
## Description
> Remove assumed copy file glob

Previously any `src` set in the config file, from where to copy files from, was appended with `**/*` when the tasks are generated. Setting `src` to `foo/bar` would internally be set as `foo/bar/**/*` for the task. This could cause undue confusion. This change is to remove this behaviour, requiring the config file to explicitly state what should be copied.

Documentation has been tweaked to reflect this change, along with smaller style tweaks to the task code itself.

This would be a major point release, due to breaking changes with `1.0.0`

## Todos
> Make sure you’ve completed these:

- [x] Does this feature run on all supported platforms?
- [x] Are there tests around this feature?
- [x] Is there documentation for this feature?
